### PR TITLE
hardware added to labels.json

### DIFF
--- a/.github/labels.json
+++ b/.github/labels.json
@@ -10,7 +10,8 @@
     "database",
     "embedded",
     "cyber-security",
-    "blockchain"
+    "blockchain",
+    "hardware"
   ],
   "internLocation": ["uzaktan", "yüzyüze"],
   "internType": ["gönüllü", "zorunlu"],


### PR DESCRIPTION
This pull request includes a small change to the `.github/labels.json` file. The change adds a new label to the list of project labels.

* [`.github/labels.json`](diffhunk://#diff-e2fc5abdfc47896652566c565d68af637e56e947a154572f33f7491bcbfaccbaL13-R14): Added "hardware" to the list of project labels.